### PR TITLE
Disable cookie consent container when hidden

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -30,7 +30,6 @@ $main-color: #3C465B;
 
   z-index: 9998;
 
-  display: flex;
   flex-wrap: nowrap;
 
   height: auto;
@@ -41,9 +40,11 @@ $main-color: #3C465B;
   color: $main-color;
 
   opacity: 0;
+  display: none;
 
   &.displayed {
     opacity: 1;
+    display: flex;
     animation: fadein 2s;
   }
 


### PR DESCRIPTION
Set display:none to avoid cookie consent box staying interactable while hidden.