### PR TITLE
Fix: Fixed container width

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -33,6 +33,7 @@ $main-color: #3C465B;
   flex-wrap: nowrap;
 
   height: auto;
+  width: 552px; /* .cc-box width + margin */
 
   font-family: Helvetica, Calibri, Arial, sans-serif;
   font-size: 14px;
@@ -140,6 +141,9 @@ $main-color: #3C465B;
 /* MEDIA */
 
 @media(max-width: 600px) {
+  .cc-container {
+    width: auto;
+  }
   .cc-box {
     width: auto;
   }


### PR DESCRIPTION
### Functional description

The popup layout container on our site occupies the entire available width of the window.
Its child main container, however, occupies a fixed width by default set to `520px` and with margins of `16px`.
To ensure that the layout container does not take up all the available width, we define a default width for it, which is the width of its main child container plus its margins.

### Screenshot

![image](https://user-images.githubusercontent.com/54936733/124487185-b07d9400-ddae-11eb-8c76-6c17107cde5b.png)

### Tested browsers

|DEVICE|BROWSER|VERSIONS|STATUS|
|------|-------|--------|------|
|DESKTOP |Chrome |      91|    ✅|
|DESKTOP |Chrome |      90|    ✅|
|MOBILE  |Chrome |      91|    ✅|
|DESKTOP |Safari |      14|    ✅|
|DESKTOP |Safari |      13|    Impossible to install on Big Sur|
|DESKTOP |Firefox |     88|    ✅|
|DESKTOP |Firefox |     87|    ✅|
|MOBILE  |Firefox |     89|    ✅|
|DESKTOP |MS Edge |     91|    ✅|
|DESKTOP |MS Edge |     90|    ✅|
|MOBILE |Samsung internet |  14|    ✅|
|MOBILE |Samsung internet |  13|    ✅|
|DESKTOP |Opera  |      77|    ✅|
|DESKTOP |Opera  |      76|    ✅|
|MOBILE  |Opera  |      64|    ✅|

